### PR TITLE
Fix waptserver install

### DIFF
--- a/source/waptserver-install/centos/install-centos-base.rst
+++ b/source/waptserver-install/centos/install-centos-base.rst
@@ -11,7 +11,7 @@
 
 .. _install_base_centos:
 
-Configuring the CentOS/ RedHat server
+Configuring the CentOS/RedHat server
 +++++++++++++++++++++++++++++++++++++
 
 In order to install a fresh CentOS7 machine (virtual or physical)
@@ -44,8 +44,8 @@ that is to say it has both the server name and the DNS suffix.
   # /etc/hostname du waptserver
   srvwapt.mydomain.lan
 
-* configure the :file:`/etc/hosts` file, be sure to put both
-  the :term:`FQDN` and the short name of the server;
+* configure the :file:`/etc/hosts` file, be sure to put both the :term:`FQDN`
+  and the short name of the server;
 
 .. code-block:: bash
 
@@ -89,7 +89,7 @@ Configuring the IP address of the WAPT Server
     reboot
 
 * if it has not already been done, :ref:`create the DNS entries
-  for the WAPT Server <srv_dns>` in the :term:`Organization` Active Directory;
+  for the WAPT Server <srv_dns>` in the :term:`Organization`'s Active Directory;
 
 * after reboot, configure the system language in English in order to have
   non-localized logs for easier searching of common errors;
@@ -129,4 +129,4 @@ Configuring the IP address of the WAPT Server
   yum install epel-release wget sudo
 
 You may now go on to the next step and :ref:`install WAPT on your
-CentOS/ RedHat <install_wapt_centos>`.
+CentOS/RedHat <install_wapt_centos>`.

--- a/source/waptserver-install/centos/install-centos-wapt.rst
+++ b/source/waptserver-install/centos/install-centos-wapt.rst
@@ -11,13 +11,13 @@
 
 .. _install_wapt_centos:
 
-Installing the WAPT Server on CentOS / RedHat
+Installing the WAPT Server on CentOS/RedHat
 +++++++++++++++++++++++++++++++++++++++++++++
 
 .. attention::
 
-  The upgrade procedure is different from installation. For upgrade, please
-  refer to :ref:`Upgrading the WAPT Server <upgrade-wapt>`.
+  The upgrade procedure is different from installation.
+  For upgrade, please refer to :ref:`Upgrading the WAPT Server <upgrade-wapt>`.
 
 Installing the WAPT Server runs a few steps:
 
@@ -147,9 +147,10 @@ Post-configuring
 
   * Choice #2 activates the initial registration based on Kerberos. (you can activate it later);
 
-  * choice #3 does not activate the kerberos authentication mechanism for the
-    initial registering of machines equipped with WAPT. The WAPT server will
-    require a login and password for each machine registering with it;
+  * choice #3 does not activate the kerberos authentication mechanism
+    for the initial registering of machines equipped with WAPT.
+    The WAPT server will require a login and password for each machine
+    registering with it;
 
   .. code-block:: bash
 
@@ -221,14 +222,14 @@ Listing of post-configuration script options:
 
 .. tabularcolumns:: |\X{2}{12}|\X{10}{12}|
 
-=============== ================================================================
-Flag            Definition
-=============== ================================================================
-*--force-https* Configures :program:`Nginx` so that *port 80
-                is permanently redirected to 443*
-=============== ================================================================
+================= ================================================================
+Flag              Definition
+================= ================================================================
+``--force-https`` Configures :program:`Nginx` so that *port 80
+                  is permanently redirected to 443*
+================= ================================================================
 
 The WAPT Server is now ready.
 
-You may go to the documentation on :ref:`installing
-the WAPT console <installing_the_WAPT_console>`!!
+You may go to the documentation on :ref:`installing the WAPT console
+<installing_the_WAPT_console>`!!

--- a/source/waptserver-install/debian/install-debian-base.rst
+++ b/source/waptserver-install/debian/install-debian-base.rst
@@ -30,9 +30,8 @@ Configuring the name of WAPT Server
 
 .. hint::
 
-  The short name of the WAPT Server must not be longer
-  than 15 characters (the limit is due to sAMAccountName restriction
-  in Active Directory).
+  The short name of the WAPT Server must not be longer than 15 characters
+  (the limit is due to sAMAccountName restriction in Active Directory).
 
 The name of the WAPT Server must be a :abbr:`FQDN (Fully Qualified Domain Name)`,
 that is to say it has both the server name and the DNS suffix.
@@ -80,10 +79,8 @@ Configuring the IP address of the WAPT Server
 * apply the network configuration by rebooting the machine
   with a :code:`reboot`;
 
-* if it has not already been done, create the DNS entry for the WAPT Server
-  in the :term:`Organization`'s Active Directory;
-
-* :ref:`srv_dns`
+* if it has not already been done, :ref:`create the DNS entries
+  for the WAPT Server <srv_dns>` in the :term:`Organization`'s Active Directory;
 
 * after reboot, configure the system language in English in order to have
   non-localized logs for easier searching of common errors;

--- a/source/waptserver-install/debian/install-debian-wapt.rst
+++ b/source/waptserver-install/debian/install-debian-wapt.rst
@@ -119,7 +119,7 @@ Post-configuring
 
     *****************
 
-    < OK >          < Cancel >
+            < OK >          < Cancel >
 
 * confirm the password;
 
@@ -129,7 +129,7 @@ Post-configuring
 
     *****************
 
-    < OK >          < Cancel >
+            < OK >          < Cancel >
 
 * choose the authentication mode for the initial registering of the WAPT agents;
 
@@ -213,13 +213,12 @@ Listing of post-configuration script options:
 
 .. tabularcolumns:: |\X{2}{12}|\X{10}{12}|
 
-=============== ================================================================
-Flag            Definition
-=============== ================================================================
-*--force-https* Configures :program:`Nginx` so that *port 80
-                is permanently redirected to 443*
-=============== ================================================================
-
+================= ================================================================
+Flag              Definition
+================= ================================================================
+``--force-https`` Configures :program:`Nginx` so that *port 80
+                  is permanently redirected to 443*
+================= ================================================================
 
 The WAPT Server is now ready.
 

--- a/source/waptserver-install/dns/dns-introduction.rst
+++ b/source/waptserver-install/dns/dns-introduction.rst
@@ -19,7 +19,7 @@ Configuring the Organization's DNS for WAPT
   **DNS configuration is not strictly required,
   but it is very strongly recommended**.
 
-In order to make make your WAPT setup easier to manage, it is strongly
+In order to make your WAPT setup easier to manage, it is strongly
 recommended to configure the :term:`DNS` server to include :term:`A field`
 or :term:`CNAME field` as below:
 

--- a/source/waptserver-install/windows/change-port.rst
+++ b/source/waptserver-install/windows/change-port.rst
@@ -30,7 +30,7 @@ Installing the WAPT Server
 
 * The installation of WAPT still needs ports 80 and 443 be available
   when installing the WAPT Server, so the first step consists of stopping
-  the service that listens on ports 80 and/ or 443 (IIS/ Anti-virus).
+  the service that listens on ports 80 and / or 443 (IIS / Anti-virus).
 
 * launch now the installation of the WAPT Server and follow the
   post-configuration procedure, but do not launch the WAPT console.
@@ -44,8 +44,8 @@ Installing the WAPT Server
     net stop WAPTNginx
     net stop waptservice
 
-* finally, restart the service that listens on ports 80 and/ or 443
-  (IIS/ Anti-virus / Web server ...);
+* finally, restart the service that listens on ports 80 and/or 443
+  (IIS / Anti-virus / Web server ...);
 
 Configuring the new listening ports in the Nginx
 ++++++++++++++++++++++++++++++++++++++++++++++++

--- a/source/waptserver-install/windows/change-port.rst
+++ b/source/waptserver-install/windows/change-port.rst
@@ -30,7 +30,7 @@ Installing the WAPT Server
 
 * The installation of WAPT still needs ports 80 and 443 be available
   when installing the WAPT Server, so the first step consists of stopping
-  the service that listens on ports 80 and / or 443 (IIS / Anti-virus).
+  the service that listens on ports 80 and/or 443 (IIS / Anti-virus).
 
 * launch now the installation of the WAPT Server and follow the
   post-configuration procedure, but do not launch the WAPT console.

--- a/source/waptserver-install/windows/index.rst
+++ b/source/waptserver-install/windows/index.rst
@@ -19,7 +19,7 @@ Installing WAPT Server on Windows
   * The WAPT Server can not be installed on a computer with services already
     listening on ports 80 and 443 (example WSUS with IIS).
 
-  * ports 80, 443 and 8080 are used by the WAPT Server and must be available;
+  * ports 80, 443 and 8088 are used by the WAPT Server and must be available;
 
   * If ports 80 and 443 are already occupied by another web service,
     you should take a look at the documentation for :ref:`changing the default
@@ -37,7 +37,7 @@ Installing WAPT Server on Windows
 
   **From WAPT Server 1.5 onward**, :program:`Nginx` is the **ONLY**
   supported web server. **Apache or IIS (with or without WSUS) are no longer
-  supported in WAPT**.
+  supported by WAPT**.
 
 In case of problems when installing WAPT, visit the :ref:`Frequently
 Asked Questions <wapt_faq>`.
@@ -49,7 +49,7 @@ Asked Questions <wapt_faq>`.
   * the WAPT Server may be installed on **64bit only** Windows 7, 8.1, 10
     and Windows Server 2008/R2, 2012/R2, 2016 and 2019;
 
-* download and execute `waptserversetup.exe <http://wapt.tranquil.it/wapt/releases/latest/waptserversetup.exe>`_;
+* download and execute `waptserversetup.exe <https://wapt.tranquil.it/wapt/releases/latest/waptserversetup.exe>`_;
 
 * choose the installation language;
 
@@ -59,8 +59,8 @@ Asked Questions <wapt_faq>`.
 
   Choose the language for WAPT
 
-* accept the GNU Public License and click on :guilabel:`Next` to go on
-  to the next step;
+* accept the GNU Public License and click on :guilabel:`Next` to go to
+  the next step;
 
 .. figure:: windows-accept-wapt-license.png
   :align: center
@@ -69,7 +69,7 @@ Asked Questions <wapt_faq>`.
   Accept the WAPT license terms
 
 * choose the installation directory (leave the default) and click
-  on :guilabel:`Next` to go on to the next step;
+  on :guilabel:`Next` to go to the next step;
 
 .. figure:: windows-installation-folder.png
   :align: center
@@ -92,7 +92,6 @@ Asked Questions <wapt_faq>`.
   :alt: Choose Password
 
   Choose Password
-
 
 * create a key if this is your first installation,
   otherwise select the existing key;

--- a/source/waptserver-install/windows/index.rst
+++ b/source/waptserver-install/windows/index.rst
@@ -19,7 +19,7 @@ Installing WAPT Server on Windows
   * The WAPT Server can not be installed on a computer with services already
     listening on ports 80 and 443 (example WSUS with IIS).
 
-  * ports 80, 443 and 8088 are used by the WAPT Server and must be available;
+  * ports 80, 443 and 8080 are used by the WAPT Server and must be available;
 
   * If ports 80 and 443 are already occupied by another web service,
     you should take a look at the documentation for :ref:`changing the default


### PR DESCRIPTION
Bonjour,

Correction des coquilles que j'ai trouvé sur l'installation de WAPT Server.

La plupart du temps on trouve "... mot/ mot ..." au lieu de "... mot/mot ...", j'ai mis à des endroits "... mot / mot ..." pour des questions de lisibilité.

Dans la doc de Windows il est dit que le WATP Server utilise les ports 80 443 et 8080, je pense que c'était une erreur et que 8080 est en fait 8088 pour l'agent WAPT (je n'ai pas installé pour vérifier).

Dans la doc d'installation WAPT pour Debian et CentOS, j'ai mis --force-https dans un code-block car un - était omis lors de la génération du code HTML. Et j'ai fait en sorte que la doc en debian et centos soit le plus proche l'une de l'autre au niveau du code (retour à la ligne au meme endroit).

Je n'ai pas inclus les nouveaux fichiers .po, mais si vous voulez je peux les générer et les inclure dans ce PR.